### PR TITLE
Add playlist JSON export and import

### DIFF
--- a/player/LibraryView.swift
+++ b/player/LibraryView.swift
@@ -159,6 +159,21 @@ struct LibraryView: View {
             .onChange(of: searchText) { recomputeFilteredRows(resetScroll: false) }
             .onChange(of: sortOrder) { recomputeFilteredRows() }
             .onChange(of: selectedTags) { recomputeFilteredRows(resetScroll: false) }
+            .focusedValue(\.playlistImportHandler, { [tracks, modelContext] exportData in
+                let (_, unmatchedCount) = PlaylistIO.importPlaylist(
+                    from: exportData,
+                    libraryTracks: tracks,
+                    modelContext: modelContext,
+                    playlistManager: appState.playlistManager
+                )
+                if unmatchedCount > 0 {
+                    let alert = NSAlert()
+                    alert.messageText = "Playlist Imported with Gaps"
+                    alert.informativeText = "\(unmatchedCount) track\(unmatchedCount == 1 ? "" : "s") could not be found in your library and were skipped."
+                    alert.alertStyle = .informational
+                    alert.runModal()
+                }
+            })
     }
 
     private var mainContent: some View {

--- a/player/PlaylistIO.swift
+++ b/player/PlaylistIO.swift
@@ -1,0 +1,193 @@
+//
+//  PlaylistIO.swift
+//  player
+//
+
+import AppKit
+import Foundation
+import SwiftData
+import SwiftUI
+import UniformTypeIdentifiers
+
+// MARK: - Exported Data Structures
+
+struct PlaylistExportData: Codable {
+    var version: Int = 1
+    var name: String
+    var dateExported: Date
+    var summary: PlaylistSummaryData
+    var tracks: [PlaylistTrackData]
+}
+
+struct PlaylistSummaryData: Codable {
+    var trackCount: Int
+    var totalDuration: TimeInterval
+    var bpmMin: Double?
+    var bpmMax: Double?
+    var bpmAverage: Double?
+    var averageRating: Double?
+    var unplayedCount: Int
+}
+
+struct PlaylistTrackData: Codable {
+    var title: String
+    var artist: String
+    var album: String
+    var duration: TimeInterval
+    var bpm: Double?
+    var rating: Int
+    var tags: [String]
+    var cuePointIn: TimeInterval?
+    var cuePointOut: TimeInterval?
+    var relativePath: String
+}
+
+// MARK: - FocusedValues
+
+extension FocusedValues {
+    @Entry var focusedPlaylist: Playlist? = nil
+    @Entry var playlistImportHandler: ((PlaylistExportData) -> Void)? = nil
+}
+
+// MARK: - PlaylistIO
+
+enum PlaylistIO {
+
+    static func makeExportData(for playlist: Playlist) -> PlaylistExportData {
+        let tracks = playlist.tracks
+        let bpms = tracks.compactMap(\.bpm).filter { $0 > 0 }
+        let ratings = tracks.map(\.rating).filter { $0 > 0 }
+
+        let summary = PlaylistSummaryData(
+            trackCount: tracks.count,
+            totalDuration: tracks.reduce(0) { $0 + $1.duration },
+            bpmMin: bpms.min(),
+            bpmMax: bpms.max(),
+            bpmAverage: bpms.isEmpty ? nil : bpms.reduce(0, +) / Double(bpms.count),
+            averageRating: ratings.isEmpty ? nil : Double(ratings.reduce(0, +)) / Double(ratings.count),
+            unplayedCount: tracks.filter { $0.playCount == 0 }.count
+        )
+
+        return PlaylistExportData(
+            name: playlist.name,
+            dateExported: Date(),
+            summary: summary,
+            tracks: tracks.map { track in
+                PlaylistTrackData(
+                    title: track.title,
+                    artist: track.artist,
+                    album: track.album,
+                    duration: track.duration,
+                    bpm: track.bpm,
+                    rating: track.rating,
+                    tags: track.tags,
+                    cuePointIn: track.cuePointIn,
+                    cuePointOut: track.cuePointOut,
+                    relativePath: track.relativePath
+                )
+            }
+        )
+    }
+
+    static func encode(_ data: PlaylistExportData) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(data)
+    }
+
+    static func decode(from data: Data) throws -> PlaylistExportData {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(PlaylistExportData.self, from: data)
+    }
+
+    /// Creates a new playlist from exported data, matching tracks by relativePath then title+artist.
+    /// Returns the new playlist and the number of tracks that could not be matched.
+    @discardableResult
+    static func importPlaylist(
+        from exportData: PlaylistExportData,
+        libraryTracks: [Track],
+        modelContext: ModelContext,
+        playlistManager: PlaylistManager
+    ) -> (playlist: Playlist, unmatchedCount: Int) {
+        let playlist = playlistManager.createPlaylist(name: exportData.name, modelContext: modelContext)
+
+        var unmatchedCount = 0
+        for trackData in exportData.tracks {
+            if let match = libraryTracks.first(where: {
+                !$0.relativePath.isEmpty && $0.relativePath == trackData.relativePath
+            }) {
+                playlistManager.addTrack(match, to: playlist, modelContext: modelContext)
+            } else if let match = libraryTracks.first(where: {
+                $0.title.lowercased() == trackData.title.lowercased() &&
+                $0.artist.lowercased() == trackData.artist.lowercased()
+            }) {
+                playlistManager.addTrack(match, to: playlist, modelContext: modelContext)
+            } else {
+                unmatchedCount += 1
+            }
+        }
+
+        return (playlist, unmatchedCount)
+    }
+}
+
+// MARK: - PlaylistCommands
+
+struct PlaylistCommands: Commands {
+    @FocusedValue(\.focusedPlaylist) private var focusedPlaylist: Playlist?
+    @FocusedValue(\.playlistImportHandler) private var importHandler: ((PlaylistExportData) -> Void)?
+
+    var body: some Commands {
+        CommandGroup(after: .importExport) {
+            Button("Export Playlist…") {
+                guard let playlist = focusedPlaylist else { return }
+                exportPlaylist(playlist)
+            }
+            .disabled(focusedPlaylist == nil)
+
+            Button("Import Playlist…") {
+                guard let handler = importHandler else { return }
+                importPlaylist(using: handler)
+            }
+            .disabled(importHandler == nil)
+        }
+    }
+
+    private func exportPlaylist(_ playlist: Playlist) {
+        guard let data = try? PlaylistIO.encode(PlaylistIO.makeExportData(for: playlist)) else { return }
+
+        let panel = NSSavePanel()
+        panel.title = "Export Playlist"
+        panel.nameFieldStringValue = "\(playlist.name).json"
+        panel.allowedContentTypes = [.json]
+        panel.canCreateDirectories = true
+
+        if panel.runModal() == .OK, let url = panel.url {
+            try? data.write(to: url)
+        }
+    }
+
+    private func importPlaylist(using handler: (PlaylistExportData) -> Void) {
+        let panel = NSOpenPanel()
+        panel.title = "Import Playlist"
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let exportData = try PlaylistIO.decode(from: data)
+            handler(exportData)
+        } catch {
+            let alert = NSAlert()
+            alert.messageText = "Could Not Import Playlist"
+            alert.informativeText = "The file doesn't appear to be a valid playlist export."
+            alert.alertStyle = .warning
+            alert.runModal()
+        }
+    }
+}

--- a/player/PlaylistWindowView.swift
+++ b/player/PlaylistWindowView.swift
@@ -15,6 +15,8 @@ struct PlaylistWindowView: View {
 
     @Environment(\.dismiss) private var dismiss
 
+    @Query private var allLibraryTracks: [Track]
+
     @State private var isRenaming = false
     @State private var renameText = ""
     @State private var showDeleteConfirmation = false
@@ -95,6 +97,22 @@ struct PlaylistWindowView: View {
                 toolbarContent(playlist)
             }
         }
+        .focusedValue(\.focusedPlaylist, playlist)
+        .focusedValue(\.playlistImportHandler, { [allLibraryTracks, modelContext] exportData in
+            let (_, unmatchedCount) = PlaylistIO.importPlaylist(
+                from: exportData,
+                libraryTracks: allLibraryTracks,
+                modelContext: modelContext,
+                playlistManager: appState.playlistManager
+            )
+            if unmatchedCount > 0 {
+                let alert = NSAlert()
+                alert.messageText = "Playlist Imported with Gaps"
+                alert.informativeText = "\(unmatchedCount) track\(unmatchedCount == 1 ? "" : "s") could not be found in your library and were skipped."
+                alert.alertStyle = .informational
+                alert.runModal()
+            }
+        })
         .sheet(isPresented: $isRenaming) {
             renameSheet(playlist)
         }

--- a/player/playerApp.swift
+++ b/player/playerApp.swift
@@ -40,6 +40,8 @@ struct playerApp: App {
         .restorationBehavior(.automatic)
 
         .commands {
+            PlaylistCommands()
+
             // Window commands
             CommandGroup(after: .newItem) {
                 Button("Open Library") {


### PR DESCRIPTION
## Summary

- Adds **Export Playlist…** and **Import Playlist…** to the File menu
- Export serializes a playlist to a pretty-printed JSON file including all track metadata (title, artist, album, BPM, rating, tags, cue points, relative path) plus a summary block matching the playlist footer stats (track count, total duration, BPM range/avg, average rating, unplayed count)
- Import reads an exported JSON file, matches tracks against the library by `relativePath` first then `title`+`artist` fallback, and creates a new playlist; shows an alert if any tracks couldn't be matched

## Implementation notes

- New file `PlaylistIO.swift` contains the `Codable` data types, encode/decode logic, import matching, and the `PlaylistCommands` SwiftUI `Commands` struct
- Menu items use `@FocusedValue` to stay context-aware: **Export** is enabled when a playlist window is frontmost (reads `\.focusedPlaylist`); **Import** is enabled when the library window or any playlist window is frontmost (reads `\.playlistImportHandler`)
- `PlaylistWindowView` registers both focused values; `LibraryView` registers the import handler — both have `modelContext` access so either window can handle an import
- File panels use `NSSavePanel`/`NSOpenPanel` directly (macOS only)

## Test plan

- [ ] Export a playlist from the File menu while a playlist window is focused — confirm a `.json` file is saved with the correct structure
- [ ] Verify Export is grayed out when no playlist window is focused
- [ ] Import the exported file — confirm a new playlist is created with all tracks present
- [ ] Import a file where some tracks don't exist in the library — confirm the alert shows the correct skipped count and the matched tracks are still added
- [ ] Import a malformed JSON file — confirm the error alert appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)